### PR TITLE
Upstream Updates & Minor Refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 rvm:
   - 2.2.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
-FROM ruby:2.4
+FROM ruby:2.2.2
 
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
+# Keep the source in /var/lib for reference
+WORKDIR /var/lib/sqs
+COPY . /var/lib/sqs
 
-ADD . /usr/src/app
-RUN bundle install --system
+# Install the bundle
+RUN bundle install
 
-COPY database.yml /database.yml
+# Configuration options
+# - SERVER: Server to use (thin, mongrel or webrick)
+# - DATABASE: Where to store the database (defaults to :memory:)
+ENV SERVER=thin DATABASE=:memory:
 
-EXPOSE 3000
+# Document the exposed port
+EXPOSE 4568
 
-CMD ["bin/fake_sqs", "-p", "3000", "--no-daemonize", "--database", "/database.yml"]
+# Expose the ENTRYPOINT
+ENTRYPOINT ["fake_sqs", "--no-daemonize"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+NAME = evenco/fake-sqs
+VERSION = 0.2.0
+IMAGE = $(NAME):$(VERSION)
+
+all: build
+
+clean:
+	@CID=$(shell docker ps -a | awk '{ print $$1 " " $$2 }' | grep $(NAME) | awk '{ print $$1 }'); if [ ! -z "$$CID" ]; then echo "Removing container which reference $(NAME)"; for container in $(CID); do docker rm -f $$container; done; fi;
+	@if docker images $(NAME) | awk '{ print $$2 }' | grep -q -F $(VERSION); then docker rmi -f $(NAME):$(VERSION); fi
+	@if docker images $(NAME) | awk '{ print $$2 }' | grep -q -F latest; then docker rmi -f $(NAME):latest; fi
+
+build:
+	docker build -t $(IMAGE) --rm .
+
+rebuild: clean
+	docker build --no-cache -t $(IMAGE)
+
+tag_latest:
+	docker tag $(IMAGE) $(NAME):latest
+
+debug:
+	docker run -t -i --rm  $(IMAGE) /bin/bash -l

--- a/README.md
+++ b/README.md
@@ -1,28 +1,36 @@
-# Fake SQS [![Build Status](https://api.travis-ci.org/iain/fake_sqs.svg?branch=master)](http://travis-ci.org/iain/fake_sqs) [![Gem Version](https://badge.fury.io/rb/fake_sqs.svg)](https://badge.fury.io/rb/fake_sqs)
+# Docker Fake SQS
 
-Fake SQS is a lightweight server that mocks the Amazon SQS API.
+[![Docker Pulls](https://img.shields.io/docker/pulls/evenco/fake-sqs.svg)](https://hub.docker.com/r/evenco/sqs/)
 
-It is extremely useful for testing SQS applications in a sandbox environment without actually
-making calls to Amazon, which not only requires a network connection, but also costs
-money.
-
-Many features are supported and if you miss something, open a pull.
-
-## Installation
-
-```
-gem install fake_sqs
-```
+Dockerized [Fake SQS](https://github.com/iain/fake_sqs).
 
 ## Running
 
-```
-fake_sqs --database /path/to/database.yml
-```
-
-## Development
+Simply run the container:
 
 ```
-bundle install
-rake
+docker run -it -p 4568:4568 evenco/fake-sqs
 ```
+
+Or, from `docker-compose.yml`:
+
+```yaml
+services:
+  sqs:
+  image: evenco/fake-sqs
+  ports:
+    - 4568
+```
+
+## Configurations
+
+The majority of configurations are set to sane defaults for use within Docker,
+however, the following environment variables are available:
+
+- `SERVER`: Server to use (`thin`, `mongrel` or `webrick`)
+- `DATABASE`: Where to store the database (`:memory:`, `./path/to/database.yml`)
+
+> __Note:__ The `SERVER` defaults to `thin`, as `webrick` attempts to do reverse
+> dns lookups on every request which slows down the service drastically. There
+> is a setting to override this within webrick, but sinatra does not allow
+> server-specific setttings to be passed down.

--- a/database.yml
+++ b/database.yml
@@ -1,6 +1,0 @@
----
-queues:
-  test:
-    QueueName: test
-    Arn: unused_arn
-    Attributes: {}

--- a/lib/fake_sqs/actions/delete_message_batch.rb
+++ b/lib/fake_sqs/actions/delete_message_batch.rb
@@ -12,11 +12,11 @@ module FakeSQS
         queue = @queues.get(queue_name)
         receipts = params.select { |k,v| k =~ /DeleteMessageBatchRequestEntry\.\d+\.ReceiptHandle/ }
 
-        deleted = receipts.each do |key, value|
+        deleted = receipts.map { |key, value|
           id = key.split('.')[1]
           queue.delete_message(value) # Broken, can only delete in-flight messages
           params.fetch("DeleteMessageBatchRequestEntry.#{id}.Id")
-        end
+        }
 
         @responder.call :DeleteMessageBatch do |xml|
           deleted.each do |id|

--- a/lib/fake_sqs/databases/file.rb
+++ b/lib/fake_sqs/databases/file.rb
@@ -8,6 +8,19 @@ module FakeSQS
     def initialize(filename)
       @filename = filename
       @queue_objects = {}
+      unless thread_safe_store?
+        # before ruby 2.4, YAML::Store cannot be declared thread safe
+        #
+        # without that declaration, attempting to have some thread B enter a
+        # store.transaction on the store while another thread A is in one
+        # already will raise an error unnecessarily.
+        #
+        # to prevent this, we'll use our own mutex around store.transaction,
+        # so only one thread can even _try_ to enter the transaction at a
+        # time.
+        @store_mutex = Mutex.new
+        @store_mutex_owner = nil
+      end
     end
 
     def load
@@ -17,8 +30,29 @@ module FakeSQS
     end
 
     def transaction
-      store.transaction do
-        yield
+      if thread_safe_store? || store_mutex_owned?
+        # if we already own the store mutex, we can expect the next line to
+        # raise (appropriately) when we try to nest transactions in the store.
+        # but if we took the other branch, the # @store_mutex.synchronize call
+        # would self-deadlock before we could raise the error.
+        store.transaction do
+          yield
+        end
+      else
+        # we still need to use an inner store.transaction block because it does
+        # more than just lock synchronization. it's unfortunately inefficient,
+        # but this isn't a production-oriented library.
+        @store_mutex.synchronize do
+          begin
+            # allows us to answer `store_mutex_owned?` above
+            @store_mutex_owner = Thread.current
+            store.transaction do
+              yield
+            end
+          ensure
+            @store_mutex_owner = nil
+          end
+        end
       end
     end
 
@@ -76,9 +110,20 @@ module FakeSQS
       store["queues"]
     end
 
-    def store
-      @store ||= YAML::Store.new(filename)
+    def thread_safe_store?
+      Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.4")
     end
 
+    def store_mutex_owned?
+      # this could be just "@store_mutex && @store_mutex.owned?" in ruby 2.x,
+      # but we still support 1.9.3 which doesn't have the "owned?" method
+      @store_mutex_owner == Thread.current
+    end
+
+    def store
+      @store ||= thread_safe_store? ?
+        YAML::Store.new(filename, true) :
+        YAML::Store.new(filename)
+    end
   end
 end


### PR DESCRIPTION
Minor updates and preparation for `evenco/fake-sqs` dockerhub

- `git pull upstream master`
- Set the version to `2.2.2`, as that's the version the `fake_sqs` project is actively tested against
- Removed `sudo: false` from travis, this is default now.
- `Dockerfile` now exposes defaults as configured, and `ENV` configuration
- `Makefile` for base docker commands
- Documentation updates